### PR TITLE
Add minimal BYD news site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# BYDNEWS
-BYD
+# BYD News
+
+This is a simple static website that displays the latest news about **BYD**. It uses the [News API](https://newsapi.org/) to retrieve articles and can be hosted on GitHub Pages.
+
+## Setup
+
+1. Obtain a free API key from [News API](https://newsapi.org/).
+2. Open `script.js` and add your key to the `API_KEY` variable.
+3. Commit the changes (or keep the key private and set it at runtime).
+4. Open `index.html` in your browser or serve the files with a static server.
+
+## Hosting on GitHub Pages
+
+1. Push the repository to your GitHub account.
+2. Enable **GitHub Pages** in the repository settings, selecting the `main` branch.
+3. Visit `https://<your-username>.github.io/<repository>` to see the site.
+
+## Files
+
+- `index.html` – main page with structure and references to JS/CSS
+- `styles.css` – styling inspired by minimalist Apple design
+- `script.js` – fetches and displays news articles
+
+Enjoy the latest BYD news!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BYD News</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="hero">
+        <h1>BYD Latest News</h1>
+    </header>
+    <main id="news-container" class="news-container">
+        <p>Loading news...</p>
+    </main>
+    <footer>
+        <p>&copy; <span id="year"></span> BYD News</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,42 @@
+const API_URL = 'https://newsapi.org/v2/everything?q=BYD&language=en&pageSize=10&apiKey=';
+const API_KEY = '';
+const container = document.getElementById('news-container');
+const yearSpan = document.getElementById('year');
+
+function setYear() {
+    const year = new Date().getFullYear();
+    yearSpan.textContent = year;
+}
+
+async function fetchNews() {
+    if (!API_KEY) {
+        container.innerHTML = '<p>Please set your News API key in <code>script.js</code>.</p>';
+        return;
+    }
+
+    try {
+        const res = await fetch(API_URL + API_KEY);
+        const data = await res.json();
+        displayArticles(data.articles);
+    } catch (err) {
+        container.innerHTML = '<p>Failed to load news.</p>';
+        console.error(err);
+    }
+}
+
+function displayArticles(articles) {
+    if (!articles || articles.length === 0) {
+        container.innerHTML = '<p>No news found.</p>';
+        return;
+    }
+
+    container.innerHTML = articles.map(article => {
+        return `<div class="article">
+            <h2><a href="${article.url}" target="_blank" rel="noopener">${article.title}</a></h2>
+            <p>${article.description || ''}</p>
+        </div>`;
+    }).join('');
+}
+
+setYear();
+fetchNews();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,67 @@
+/* Basic reset */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+        Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+body {
+    background-color: #fff;
+    color: #333;
+    line-height: 1.6;
+}
+
+.hero {
+    background: #000;
+    color: #fff;
+    text-align: center;
+    padding: 4rem 1rem;
+}
+
+.hero h1 {
+    font-size: 3rem;
+    letter-spacing: -0.03em;
+}
+
+.news-container {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+.article {
+    border-bottom: 1px solid #e5e5e5;
+    padding: 1.5rem 0;
+}
+
+.article:last-child {
+    border-bottom: none;
+}
+
+.article h2 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.article p {
+    color: #666;
+}
+
+.article a {
+    color: #0070c9;
+    text-decoration: none;
+}
+
+.article a:hover {
+    text-decoration: underline;
+}
+
+footer {
+    text-align: center;
+    padding: 2rem 0;
+    color: #666;
+    font-size: 0.875rem;
+    border-top: 1px solid #e5e5e5;
+}


### PR DESCRIPTION
## Summary
- create Apple-inspired static site for BYD news
- implement API driven article list using News API
- add simple styling and instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687346d0a4288322a46ad80b3d9bce80